### PR TITLE
Drop eslint-plugin-deprecation to reduce TypeScript 5 updating blocker

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,7 +3,6 @@ env:
   es2021: true
   jest/globals: true
 plugins:
-  - deprecation
   - '@typescript-eslint'
 extends:
   - plugin:@typescript-eslint/recommended
@@ -20,7 +19,6 @@ overrides:
       filenames/match-regex: 'off'
 rules:
   i18n-text/no-en: 'off'
-  deprecation/deprecation: error
   no-restricted-syntax:
     - error
     - selector: TSEnumDeclaration

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "esbuild": "0.17.12",
         "esbuild-jest-transform": "^1.1.1",
         "eslint": "^8.36.0",
-        "eslint-plugin-deprecation": "^1.3.3",
         "eslint-plugin-jest": "^27.2.1",
         "jest": "^29.5.0",
         "ts-node": "^10.9.1",
@@ -2203,25 +2202,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.27.1.tgz",
-      "integrity": "sha512-Vd8uewIixGP93sEnmTRIH6jHZYRQRkGPDPpapACMvitJKX8335VHNyqKTE+mZ+m3E2c5VznTZfSsSsS5IF7vUA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/utils": "5.27.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.56.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz",
@@ -3587,27 +3567,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/eslint-plugin-deprecation": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.3.tgz",
-      "integrity": "sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": "^5.0.0",
-        "tslib": "^2.3.1",
-        "tsutils": "^3.21.0"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "typescript": "^3.7.5 || ^4.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-deprecation/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
     },
     "node_modules/eslint-plugin-jest": {
       "version": "27.2.1",
@@ -7962,15 +7921,6 @@
         }
       }
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.27.1.tgz",
-      "integrity": "sha512-Vd8uewIixGP93sEnmTRIH6jHZYRQRkGPDPpapACMvitJKX8335VHNyqKTE+mZ+m3E2c5VznTZfSsSsS5IF7vUA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/utils": "5.27.1"
-      }
-    },
     "@typescript-eslint/parser": {
       "version": "5.56.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz",
@@ -8871,25 +8821,6 @@
           "requires": {
             "p-limit": "^3.0.2"
           }
-        }
-      }
-    },
-    "eslint-plugin-deprecation": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.3.tgz",
-      "integrity": "sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/experimental-utils": "^5.0.0",
-        "tslib": "^2.3.1",
-        "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "esbuild": "0.17.12",
     "esbuild-jest-transform": "^1.1.1",
     "eslint": "^8.36.0",
-    "eslint-plugin-deprecation": "^1.3.3",
     "eslint-plugin-jest": "^27.2.1",
     "jest": "^29.5.0",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
Same as https://github.com/kachick/action-typescript-template/pull/293