### PR TITLE
Remove outdated workaround, fixed since Nodejs 20.6.0

### DIFF
--- a/scripts/run_tests.ts
+++ b/scripts/run_tests.ts
@@ -2,14 +2,8 @@ import { readdirSync } from 'node:fs';
 import { join } from 'path';
 import { execFileSync } from 'node:child_process';
 
-// TODO: Update with enabling withFileTypes if fixed the feature
-//
-// Do NOT specify both recursive and withFileTypes as true, entries will be missed in v20.5.1
-//   - https://github.com/kachick/times_kachick/issues/244
-//   - https://github.com/nodejs/node/pull/48698
-const baseNames = readdirSync('src', { encoding: 'utf-8', recursive: true, withFileTypes: false });
-
-const testPaths = baseNames.flatMap((name) => name.endsWith('.test.ts') ? [join('src', name)] : []);
+const dirEnts = readdirSync('.', { encoding: 'utf-8', recursive: true, withFileTypes: true });
+const testPaths = dirEnts.flatMap((dirent) => dirent.name.endsWith('.test.ts') ? [join(dirent.path, dirent.name)] : []);
 
 console.log('Starting to run tests for', testPaths);
 


### PR DESCRIPTION
https://github.com/kachick/wait-other-jobs/pull/572
https://github.com/kachick/times_kachick/issues/244