### PR TITLE
Add support for GHE

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Full list of the options
 
 | NAME                                | DESCRIPTION                                                    | TYPE     | DEFAULT               | OPTIONS                                  |
 | ----------------------------------- | -------------------------------------------------------------- | -------- | --------------------- | ---------------------------------------- |
+| `github-api-url`                    | The Github API endpoint. Override for Github Enterprise usage. | `string` | `true`                | `https://api.github.com`                 |
 | `github-token`                      | The GITHUB_TOKEN secret. You can use PAT if you want.          | `string` | `${{ github.token }}` |                                          |
 | `wait-seconds-before-first-polling` | Wait this interval before first polling                        | `number` | `10`                  |                                          |
 | `min-interval-seconds`              | Wait this interval or the multiplied value (and jitter)        | `number` | `15`                  |                                          |
@@ -88,6 +89,15 @@ permissions:
   contents: read # Since v2
   checks: read
   actions: read
+```
+
+## Support for Github Enterprise
+
+To run this action in your Github Enterprise (GHE) instance you need to override `github-api-url`:
+
+```yaml
+with:
+  github-api-url: 'https://ghe-host.acme.net/api/v3'
 ```
 
 ## outputs.<output_id>

--- a/__tests__/schema.test.ts
+++ b/__tests__/schema.test.ts
@@ -8,6 +8,7 @@ import { deepStrictEqual } from 'node:assert/strict';
 import { checkSync } from 'recheck';
 
 const defaultOptions = Object.freeze({
+  apiUrl: 'https://api.github.com',
   isEarlyExit: true,
   attemptLimits: 1000,
   waitList: [],
@@ -21,6 +22,7 @@ const defaultOptions = Object.freeze({
 
 test('Options keep given values', () => {
   optionsEqual({
+    apiUrl: 'https://api.github.com',
     isEarlyExit: true,
     attemptLimits: 1000,
     waitList: [],

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'The GITHUB_TOKEN secret'
     required: false
     default: ${{ github.token }}
+  github-api-url:
+    description: 'Github API URL'
+    required: true
+    default: 'https://api.github.com'
   wait-seconds-before-first-polling:
     description: 'Wait this seconds before first polling'
     required: false

--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -6,10 +6,11 @@ import { Check, Trigger } from './schema.ts';
 const PaginatableOctokit = Octokit.plugin(paginateGraphQL);
 
 export async function fetchChecks(
+  apiUrl: string,
   token: string,
   trigger: Trigger,
 ): Promise<Check[]> {
-  const octokit = new PaginatableOctokit({ auth: token });
+  const octokit = new PaginatableOctokit({ auth: token, baseUrl: apiUrl });
   const { repository: { object: { checkSuites } } } = await octokit.graphql.paginate<
     { repository: { object: { checkSuites: Commit['checkSuites'] } } }
   >(

--- a/src/input.ts
+++ b/src/input.ts
@@ -47,8 +47,10 @@ export function parseInput(): { trigger: Trigger; options: Options; githubToken:
   const isEarlyExit = getBooleanInput('early-exit', { required: true, trimWhitespace: true });
   const shouldSkipSameWorkflow = getBooleanInput('skip-same-workflow', { required: true, trimWhitespace: true });
   const isDryRun = getBooleanInput('dry-run', { required: true, trimWhitespace: true });
+  const apiUrl = getInput('github-api-url', { required: true, trimWhitespace: true });
 
   const options = Options.parse({
+    apiUrl,
     initialDuration: Durationable.parse({ seconds: waitSecondsBeforeFirstPolling }),
     leastInterval: Durationable.parse({ seconds: minIntervalSeconds }),
     retryMethod,

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,7 +91,7 @@ async function run(): Promise<void> {
     // Put getting elapsed time before of fetchChecks to keep accuracy of the purpose
     const elapsed = Temporal.Duration.from({ milliseconds: Math.ceil(performance.now() - startedAt) });
     startGroup(`Polling ${attempts}: ${(new Date()).toISOString()} # total elapsed ${readableDuration(elapsed)}`);
-    const checks = await fetchChecks(githubToken, trigger);
+    const checks = await fetchChecks(options.apiUrl, githubToken, trigger);
 
     const report = generateReport(
       getSummaries(checks, trigger),

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -109,6 +109,7 @@ export type RetryMethod = z.infer<typeof retryMethods>;
 // - Do not specify default values with zod. That is an action.yml role
 // - Do not include secrets here, for example githubToken. See https://github.com/colinhacks/zod/issues/1783
 export const Options = z.object({
+  apiUrl: z.string().url(),
   waitList: WaitList,
   skipList: SkipList,
   initialDuration: Duration,


### PR DESCRIPTION
By providing github-api-url we can enable support for Github Enterprise.
In some cases it might be available for octokit automatically but it's
safer to provide an override.