### PR TITLE
Add support for .yaml file extension

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -66,7 +66,7 @@ export function getDuration(durationable: string | MyDurationLike): Duration {
   throw new Error('unexpected value is specified in durations');
 }
 
-const workflowFile = z.string().endsWith('.yml');
+const workflowFile = z.string().regex(/\.(yml|yaml)$/);
 const matchAllJobs = z.object({
   workflowFile: workflowFile,
   jobName: z.undefined(), // Preferring undefined over null for backward compatibility


### PR DESCRIPTION
First of all, thank you so much for developing this action! Very very useful.

I noticed that GitHub officially supports both `.yml` and `.yaml` file extensions for workflows (source: [link](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#about-yaml-syntax-for-workflows)), so this simple PR just **adds support for the `.yaml` case** to the schema validation 🙂 

Let me know what you think! Thanks