### PR TITLE
Remove unnecessary npm versions in deno.lock

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -72,24 +72,6 @@
   "workspace": {
     "dependencies": [
       "jsr:@david/dax@0.42"
-    ],
-    "packageJson": {
-      "dependencies": [
-        "npm:@actions/core@^1.11.1",
-        "npm:@actions/github@6",
-        "npm:@octokit/core@^6.1.3",
-        "npm:@octokit/graphql-schema@^15.25.0",
-        "npm:@octokit/plugin-paginate-graphql@^5.2.4",
-        "npm:@tsconfig/node20@^20.1.4",
-        "npm:@tsconfig/strictest@^2.0.5",
-        "npm:@types/node@^20.17.17",
-        "npm:ansi-styles@^6.2.1",
-        "npm:recheck@^4.4.5",
-        "npm:temporal-polyfill@~0.2.5",
-        "npm:tsx@^4.19.2",
-        "npm:typescript@^5.7.3",
-        "npm:zod@^3.24.1"
-      ]
-    }
+    ]
   }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,8 @@
         in
         {
           default = pkgs.mkShellNoCC {
+            # https://github.com/denoland/deno/issues/17916
+            env.DENO_NO_PACKAGE_JSON = "1";
             buildInputs = (
               with pkgs;
               [


### PR DESCRIPTION
Follow #1018

I've noticed this problem in https://github.com/kachick/wait-other-jobs/pull/1021#issuecomment-2632521701
