### PR TITLE
Force update some npm packages which has ReDoS reports

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,7 +33,8 @@
       ],
       "matchPackageNames": [
         "undici",
-        "@octokit/plugin-paginate-rest"
+        "@octokit/plugin-paginate-rest",
+        "@octokit/endpoint"
       ],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,7 +34,8 @@
       "matchPackageNames": [
         "undici",
         "@octokit/plugin-paginate-rest",
-        "@octokit/endpoint"
+        "@octokit/endpoint",
+        "@octokit/request"
       ],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,6 @@
         "npm"
       ],
       "matchPackageNames": [
-        "esbuild",
         "undici"
       ],
       "matchUpdateTypes": ["major", "minor"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,8 @@
         "npm"
       ],
       "matchPackageNames": [
-        "undici"
+        "undici",
+        "@octokit/plugin-paginate-rest"
       ],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,7 +35,8 @@
         "undici",
         "@octokit/plugin-paginate-rest",
         "@octokit/endpoint",
-        "@octokit/request"
+        "@octokit/request",
+        "@octokit/request-error"
       ],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false

--- a/dist/index.js
+++ b/dist/index.js
@@ -20825,9 +20825,9 @@ var require_before_after_hook = __commonJS({
   }
 });
 
-// node_modules/.pnpm/@octokit+endpoint@9.0.5/node_modules/@octokit/endpoint/dist-node/index.js
+// node_modules/.pnpm/@octokit+endpoint@9.0.6/node_modules/@octokit/endpoint/dist-node/index.js
 var require_dist_node2 = __commonJS({
-  "node_modules/.pnpm/@octokit+endpoint@9.0.5/node_modules/@octokit/endpoint/dist-node/index.js"(exports, module) {
+  "node_modules/.pnpm/@octokit+endpoint@9.0.6/node_modules/@octokit/endpoint/dist-node/index.js"(exports, module) {
     "use strict";
     var __defProp2 = Object.defineProperty;
     var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
@@ -20852,7 +20852,7 @@ var require_dist_node2 = __commonJS({
     });
     module.exports = __toCommonJS(dist_src_exports);
     var import_universal_user_agent5 = require_dist_node();
-    var VERSION5 = "9.0.5";
+    var VERSION5 = "9.0.6";
     var userAgent2 = `octokit-endpoint.js/${VERSION5} ${(0, import_universal_user_agent5.getUserAgent)()}`;
     var DEFAULTS2 = {
       method: "GET",
@@ -20941,9 +20941,9 @@ var require_dist_node2 = __commonJS({
         return `${name}=${encodeURIComponent(parameters[name])}`;
       }).join("&");
     }
-    var urlVariableRegex2 = /\{[^}]+\}/g;
+    var urlVariableRegex2 = /\{[^{}}]+\}/g;
     function removeNonChars2(variableName) {
-      return variableName.replace(/^\W+|\W+$/g, "").split(/,/);
+      return variableName.replace(/(?:^\W+)|(?:(?<!\W)\W+$)/g, "").split(/,/);
     }
     function extractUrlVariableNames2(url) {
       const matches = url.match(urlVariableRegex2);
@@ -21123,7 +21123,7 @@ var require_dist_node2 = __commonJS({
         }
         if (url.endsWith("/graphql")) {
           if (options.mediaType.previews?.length) {
-            const previewsFromAcceptHeader = headers.accept.match(/[\w-]+(?=-preview)/g) || [];
+            const previewsFromAcceptHeader = headers.accept.match(/(?<![\w-])[\w-]+(?=-preview)/g) || [];
             headers.accept = previewsFromAcceptHeader.concat(options.mediaType.previews).map((preview) => {
               const format = options.mediaType.format ? `.${options.mediaType.format}` : "+json";
               return `application/vnd.github.${preview}-preview${format}`;
@@ -21263,9 +21263,9 @@ var require_once = __commonJS({
   }
 });
 
-// node_modules/.pnpm/@octokit+request-error@5.1.0/node_modules/@octokit/request-error/dist-node/index.js
+// node_modules/.pnpm/@octokit+request-error@5.1.1/node_modules/@octokit/request-error/dist-node/index.js
 var require_dist_node4 = __commonJS({
-  "node_modules/.pnpm/@octokit+request-error@5.1.0/node_modules/@octokit/request-error/dist-node/index.js"(exports, module) {
+  "node_modules/.pnpm/@octokit+request-error@5.1.1/node_modules/@octokit/request-error/dist-node/index.js"(exports, module) {
     "use strict";
     var __create2 = Object.create;
     var __defProp2 = Object.defineProperty;
@@ -21323,7 +21323,7 @@ var require_dist_node4 = __commonJS({
         if (options.request.headers.authorization) {
           requestCopy.headers = Object.assign({}, options.request.headers, {
             authorization: options.request.headers.authorization.replace(
-              / .*$/,
+              /(?<! ) .*$/,
               " [REDACTED]"
             )
           });
@@ -21355,9 +21355,9 @@ var require_dist_node4 = __commonJS({
   }
 });
 
-// node_modules/.pnpm/@octokit+request@8.4.0/node_modules/@octokit/request/dist-node/index.js
+// node_modules/.pnpm/@octokit+request@8.4.1/node_modules/@octokit/request/dist-node/index.js
 var require_dist_node5 = __commonJS({
-  "node_modules/.pnpm/@octokit+request@8.4.0/node_modules/@octokit/request/dist-node/index.js"(exports, module) {
+  "node_modules/.pnpm/@octokit+request@8.4.1/node_modules/@octokit/request/dist-node/index.js"(exports, module) {
     "use strict";
     var __defProp2 = Object.defineProperty;
     var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
@@ -21383,7 +21383,7 @@ var require_dist_node5 = __commonJS({
     module.exports = __toCommonJS(dist_src_exports);
     var import_endpoint2 = require_dist_node2();
     var import_universal_user_agent5 = require_dist_node();
-    var VERSION5 = "8.4.0";
+    var VERSION5 = "8.4.1";
     function isPlainObject3(value) {
       if (typeof value !== "object" || value === null)
         return false;
@@ -21434,7 +21434,7 @@ var require_dist_node5 = __commonJS({
           headers[keyAndValue[0]] = keyAndValue[1];
         }
         if ("deprecation" in headers) {
-          const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
+          const matches = headers.link && headers.link.match(/<([^<>]+)>; rel="deprecation"/);
           const deprecationLink = matches && matches.pop();
           log.warn(
             `[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`
@@ -24089,9 +24089,9 @@ var require_dist_node9 = __commonJS({
   }
 });
 
-// node_modules/.pnpm/@octokit+plugin-paginate-rest@9.2.1_@octokit+core@5.2.0/node_modules/@octokit/plugin-paginate-rest/dist-node/index.js
+// node_modules/.pnpm/@octokit+plugin-paginate-rest@9.2.2_@octokit+core@5.2.0/node_modules/@octokit/plugin-paginate-rest/dist-node/index.js
 var require_dist_node10 = __commonJS({
-  "node_modules/.pnpm/@octokit+plugin-paginate-rest@9.2.1_@octokit+core@5.2.0/node_modules/@octokit/plugin-paginate-rest/dist-node/index.js"(exports, module) {
+  "node_modules/.pnpm/@octokit+plugin-paginate-rest@9.2.2_@octokit+core@5.2.0/node_modules/@octokit/plugin-paginate-rest/dist-node/index.js"(exports, module) {
     "use strict";
     var __defProp2 = Object.defineProperty;
     var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
@@ -24118,7 +24118,7 @@ var require_dist_node10 = __commonJS({
       paginatingEndpoints: () => paginatingEndpoints
     });
     module.exports = __toCommonJS(dist_src_exports);
-    var VERSION5 = "9.2.1";
+    var VERSION5 = "9.2.2";
     function normalizePaginatedListResponse(response) {
       if (!response.data) {
         return {
@@ -24162,7 +24162,7 @@ var require_dist_node10 = __commonJS({
               const response = await requestMethod({ method, url, headers });
               const normalizedResponse = normalizePaginatedListResponse(response);
               url = ((normalizedResponse.headers.link || "").match(
-                /<([^>]+)>;\s*rel="next"/
+                /<([^<>]+)>;\s*rel="next"/
               ) || [])[1];
               return { value: normalizedResponse };
             } catch (error2) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
       "undici@<=5.28.4": "^5.28.5",
       "@octokit/plugin-paginate-rest@<9.2.2": "^9.2.2",
       "@octokit/endpoint@<9.0.5": "^9.0.6",
-      "@octokit/request@<8.4.1": "^8.4.1"
+      "@octokit/request@<8.4.1": "^8.4.1",
+      "@octokit/request-error@<5.1.1": "^5.1.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "overrides": {
       "undici@<=5.28.4": "^5.28.5",
       "@octokit/plugin-paginate-rest@<9.2.2": "^9.2.2",
-      "@octokit/endpoint@<9.0.5": "^9.0.6"
+      "@octokit/endpoint@<9.0.5": "^9.0.6",
+      "@octokit/request@<8.4.1": "^8.4.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "pnpm": {
     "overrides": {
-      "undici@<=5.28.4": "^5.28.5",
+      "undici@<5.28.5": "^5.28.5",
       "@octokit/plugin-paginate-rest@<9.2.2": "^9.2.2",
-      "@octokit/endpoint@<9.0.5": "^9.0.6",
+      "@octokit/endpoint@<9.0.6": "^9.0.6",
       "@octokit/request@<8.4.1": "^8.4.1",
       "@octokit/request-error@<5.1.1": "^5.1.1"
     }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "pnpm": {
     "overrides": {
       "undici@<=5.28.4": "^5.28.5",
-      "@octokit/plugin-paginate-rest@<9.2.2": "^9.2.2"
+      "@octokit/plugin-paginate-rest@<9.2.2": "^9.2.2",
+      "@octokit/endpoint@<9.0.5": "^9.0.6"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "pnpm": {
     "overrides": {
-      "undici@<=5.28.4": "^5.28.5"
+      "undici@<=5.28.4": "^5.28.5",
+      "@octokit/plugin-paginate-rest@<9.2.2": "^9.2.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   undici@<=5.28.4: ^5.28.5
   '@octokit/plugin-paginate-rest@<9.2.2': ^9.2.2
+  '@octokit/endpoint@<9.0.5': ^9.0.6
 
 importers:
 
@@ -253,8 +254,8 @@ packages:
     resolution: {integrity: sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==}
     engines: {node: '>= 18'}
 
-  '@octokit/endpoint@9.0.5':
-    resolution: {integrity: sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==}
+  '@octokit/endpoint@9.0.6':
+    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
     engines: {node: '>= 18'}
 
   '@octokit/graphql-schema@15.25.0':
@@ -568,7 +569,7 @@ snapshots:
       '@octokit/types': 13.8.0
       universal-user-agent: 7.0.2
 
-  '@octokit/endpoint@9.0.5':
+  '@octokit/endpoint@9.0.6':
     dependencies:
       '@octokit/types': 13.8.0
       universal-user-agent: 6.0.1
@@ -620,7 +621,7 @@ snapshots:
 
   '@octokit/request@8.4.0':
     dependencies:
-      '@octokit/endpoint': 9.0.5
+      '@octokit/endpoint': 9.0.6
       '@octokit/request-error': 5.1.0
       '@octokit/types': 13.8.0
       universal-user-agent: 6.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  undici@<=5.28.4: ^5.28.5
+  undici@<5.28.5: ^5.28.5
   '@octokit/plugin-paginate-rest@<9.2.2': ^9.2.2
-  '@octokit/endpoint@<9.0.5': ^9.0.6
+  '@octokit/endpoint@<9.0.6': ^9.0.6
   '@octokit/request@<8.4.1': ^8.4.1
   '@octokit/request-error@<5.1.1': ^5.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@octokit/plugin-paginate-rest@<9.2.2': ^9.2.2
   '@octokit/endpoint@<9.0.5': ^9.0.6
   '@octokit/request@<8.4.1': ^8.4.1
+  '@octokit/request-error@<5.1.1': ^5.1.1
 
 importers:
 
@@ -294,10 +295,6 @@ packages:
     peerDependencies:
       '@octokit/core': '5'
 
-  '@octokit/request-error@5.1.0':
-    resolution: {integrity: sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==}
-    engines: {node: '>= 18'}
-
   '@octokit/request-error@5.1.1':
     resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
     engines: {node: '>= 18'}
@@ -554,7 +551,7 @@ snapshots:
       '@octokit/auth-token': 4.0.0
       '@octokit/graphql': 7.1.0
       '@octokit/request': 8.4.1
-      '@octokit/request-error': 5.1.0
+      '@octokit/request-error': 5.1.1
       '@octokit/types': 13.8.0
       before-after-hook: 2.2.3
       universal-user-agent: 6.0.1
@@ -613,12 +610,6 @@ snapshots:
     dependencies:
       '@octokit/core': 5.2.0
       '@octokit/types': 12.6.0
-
-  '@octokit/request-error@5.1.0':
-    dependencies:
-      '@octokit/types': 13.8.0
-      deprecation: 2.3.1
-      once: 1.4.0
 
   '@octokit/request-error@5.1.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   undici@<=5.28.4: ^5.28.5
+  '@octokit/plugin-paginate-rest@<9.2.2': ^9.2.2
 
 importers:
 
@@ -279,8 +280,8 @@ packages:
     peerDependencies:
       '@octokit/core': '>=6'
 
-  '@octokit/plugin-paginate-rest@9.2.1':
-    resolution: {integrity: sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==}
+  '@octokit/plugin-paginate-rest@9.2.2':
+    resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@octokit/core': '5'
@@ -446,7 +447,7 @@ snapshots:
     dependencies:
       '@actions/http-client': 2.2.1
       '@octokit/core': 5.2.0
-      '@octokit/plugin-paginate-rest': 9.2.1(@octokit/core@5.2.0)
+      '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.0)
       '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.0)
 
   '@actions/http-client@2.2.1':
@@ -597,7 +598,7 @@ snapshots:
     dependencies:
       '@octokit/core': 6.1.4
 
-  '@octokit/plugin-paginate-rest@9.2.1(@octokit/core@5.2.0)':
+  '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.0)':
     dependencies:
       '@octokit/core': 5.2.0
       '@octokit/types': 12.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   undici@<=5.28.4: ^5.28.5
   '@octokit/plugin-paginate-rest@<9.2.2': ^9.2.2
   '@octokit/endpoint@<9.0.5': ^9.0.6
+  '@octokit/request@<8.4.1': ^8.4.1
 
 importers:
 
@@ -297,12 +298,16 @@ packages:
     resolution: {integrity: sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==}
     engines: {node: '>= 18'}
 
+  '@octokit/request-error@5.1.1':
+    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
+    engines: {node: '>= 18'}
+
   '@octokit/request-error@6.1.7':
     resolution: {integrity: sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==}
     engines: {node: '>= 18'}
 
-  '@octokit/request@8.4.0':
-    resolution: {integrity: sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==}
+  '@octokit/request@8.4.1':
+    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
     engines: {node: '>= 18'}
 
   '@octokit/request@9.2.1':
@@ -548,7 +553,7 @@ snapshots:
     dependencies:
       '@octokit/auth-token': 4.0.0
       '@octokit/graphql': 7.1.0
-      '@octokit/request': 8.4.0
+      '@octokit/request': 8.4.1
       '@octokit/request-error': 5.1.0
       '@octokit/types': 13.8.0
       before-after-hook: 2.2.3
@@ -581,7 +586,7 @@ snapshots:
 
   '@octokit/graphql@7.1.0':
     dependencies:
-      '@octokit/request': 8.4.0
+      '@octokit/request': 8.4.1
       '@octokit/types': 13.8.0
       universal-user-agent: 6.0.1
 
@@ -615,14 +620,20 @@ snapshots:
       deprecation: 2.3.1
       once: 1.4.0
 
+  '@octokit/request-error@5.1.1':
+    dependencies:
+      '@octokit/types': 13.8.0
+      deprecation: 2.3.1
+      once: 1.4.0
+
   '@octokit/request-error@6.1.7':
     dependencies:
       '@octokit/types': 13.8.0
 
-  '@octokit/request@8.4.0':
+  '@octokit/request@8.4.1':
     dependencies:
       '@octokit/endpoint': 9.0.6
-      '@octokit/request-error': 5.1.0
+      '@octokit/request-error': 5.1.1
       '@octokit/types': 13.8.0
       universal-user-agent: 6.0.1
 


### PR DESCRIPTION
- **Remove outdated esbuild special config from renovate.json**
- **Force apply patched version for @octokit/plugin-paginate-rest**
- **Force apply patched version for @octokit/endpoint**
- **Force apply patched version for @octokit/request**
- **Force apply patched version for @octokit/request-error**

GitHub does not reply https://github.com/actions/toolkit/issues/1960 and we should manually bump these by myself

And without this, dependabot internal reports are much noisy. See #998
