### PR TITLE
Remove outdated pnpm.overrides

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,20 +29,6 @@
       ],
       "matchUpdateTypes": ["major"],
       "enabled": false
-    },
-    {
-      "matchDatasources": [
-        "npm"
-      ],
-      "matchPackageNames": [
-        "undici",
-        "@octokit/plugin-paginate-rest",
-        "@octokit/endpoint",
-        "@octokit/request",
-        "@octokit/request-error"
-      ],
-      "matchUpdateTypes": ["major", "minor"],
-      "enabled": false
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -33,11 +33,5 @@
     "recheck": "^4.5.0",
     "tsx": "^4.20.3",
     "typescript": "^5.9.2"
-  },
-  "pnpm": {
-    "overrides": {
-      "undici@<5.28.5": "^5.29.0",
-      "@octokit/plugin-paginate-rest@<9.2.2": "^9.2.2"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  undici@<5.28.5: ^5.29.0
-  '@octokit/plugin-paginate-rest@<9.2.2': ^9.2.2
-
 importers:
 
   .:


### PR DESCRIPTION
We can remove plugin-paginate-rest patch since https://github.com/actions/toolkit/commit/2b476323c4f1e1c6023cc24e3ae093b9d5630264
