### PR TITLE
Ensure pure backend on recheck to consider use-case on NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,10 @@
 
               # Correct nixd inlay hints
               NIX_PATH = "nixpkgs=${nixpkgs.outPath}";
+
+              # NixOS cannot run external pre-built CLI by default
+              RECHECK_BACKEND = "pure";
+              RECHECK_SYNC_BACKEND = "pure";
             };
 
             buildInputs = (


### PR DESCRIPTION
Without this change

```
Could not start dynamically linked executable: /home/kachick/repos/github.com/kachick/wait-other-jobs/node_modules/.pnpm/recheck-linux-x64@4.5.0/node_modules/recheck-linux-x64/recheck
NixOS cannot run dynamically linked executables intended for generic
linux environments out of the box. For more information, see:
https://nix.dev/permalink/stub-ld
```

on NixOS

It seems appeared from https://github.com/kachick/wait-other-jobs/pull/1094
