### PR TITLE
Report nix store diff in PRs which updates flake.lock

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,3 +23,4 @@ jobs:
         with:
           # https://spdx.org/licenses/
           allow-licenses: MIT, BSD-3-Clause, BSD-2-Clause, 0BSD, Unlicense, ISC, Apache-2.0, CC-BY-4.0
+          allow-dependencies-licenses: pkg:githubactions/NixOS/nix-installer-action

--- a/.github/workflows/nix-diff.yml
+++ b/.github/workflows/nix-diff.yml
@@ -1,4 +1,4 @@
-name: ❄️ Nix Diff
+name: ❄️
 on:
   pull_request:
     paths:

--- a/.github/workflows/nix-diff.yml
+++ b/.github/workflows/nix-diff.yml
@@ -59,12 +59,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           DIFF_CONTENT: ${{ steps.diff.outputs.diff }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
+
+          # Minimize previous comments to reduce noise
+          # https://github.com/kachick/dotfiles/blob/2efec539ec0581ba9e5833c8d4fb3104fe1c9633/.github/workflows/nix-diff.yml#L101-L121
+          gh api -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/{owner}/{repo}/issues/${PR_NUMBER}/comments" --paginate | \
+              jq --raw-output '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("nix-diff-report"))) | .node_id' | \
+              xargs --no-run-if-empty --replace='{node_id}' \
+                gh api graphql --raw-field subjectId="{node_id}" \
+                  --raw-field query='mutation($subjectId:ID!) {
+                    minimizeComment(input: { subjectId: $subjectId, classifier: OUTDATED }) {
+                      minimizedComment { isMinimized }
+                    }
+                  }'
+
           cat <<EOF > comment.md
           ### ❄️ Nix Store Diff (flake.lock update)
+          <!-- nix-diff-report -->
 
           \`\`\`text
           $DIFF_CONTENT
           \`\`\`
           EOF
-          gh pr comment "${{ github.event.pull_request.number }}" --body-file comment.md
+          gh pr comment "$PR_NUMBER" --body-file comment.md

--- a/.github/workflows/nix-diff.yml
+++ b/.github/workflows/nix-diff.yml
@@ -58,12 +58,13 @@ jobs:
         if: ${{ steps.diff.outputs.diff != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          DIFF_CONTENT: ${{ steps.diff.outputs.diff }}
         run: |
           cat <<EOF > comment.md
           ### ❄️ Nix Store Diff (flake.lock update)
 
           \`\`\`text
-          ${{ steps.diff.outputs.diff }}
+          $DIFF_CONTENT
           \`\`\`
           EOF
           gh pr comment "${{ github.event.pull_request.number }}" --body-file comment.md

--- a/.github/workflows/nix-diff.yml
+++ b/.github/workflows/nix-diff.yml
@@ -1,4 +1,4 @@
-name: ❄️
+name: ❄️🔍
 on:
   pull_request:
     paths:

--- a/.github/workflows/nix-diff.yml
+++ b/.github/workflows/nix-diff.yml
@@ -1,0 +1,69 @@
+name: ❄️ Nix Diff
+on:
+  pull_request:
+    paths:
+      - 'flake.lock'
+      - '.github/workflows/nix-diff.yml'
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  diff:
+    timeout-minutes: 60
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+        with:
+          fetch-depth: 0 # Required for the base SHA to exist in local git
+          persist-credentials: false
+
+      - uses: NixOS/nix-installer-action@main
+        with:
+          extra-conf: |
+            sandbox = true
+            accept-flake-config = true
+
+      - name: Diff closures
+        id: diff
+        run: |
+          set -euo pipefail
+          SYSTEM=$(nix eval --raw --impure --expr "builtins.currentSystem")
+
+          echo "Evaluating PR derivation..."
+          PR_DRV=$(nix path-info --derivation ".#devShells.${SYSTEM}.default")
+
+          echo "Evaluating base derivation..."
+          # Use local git repository and the base SHA to evaluate without switching branches
+          BASE_DRV=$(nix path-info --derivation "git+file://${{ github.workspace }}?rev=${{ github.event.pull_request.base.sha }}#devShells.${SYSTEM}.default")
+
+          if [ "$PR_DRV" = "$BASE_DRV" ]; then
+            echo "No changes in derivation."
+            echo "diff=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Generating diff..."
+          # nix store diff-closures compares the closures of the two derivations.
+          DIFF=$(nix store diff-closures "$BASE_DRV" "$PR_DRV")
+
+          {
+            echo "diff<<EOF"
+            echo "$DIFF"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post comment
+        if: ${{ steps.diff.outputs.diff != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cat <<EOF > comment.md
+          ### ❄️ Nix Store Diff (flake.lock update)
+
+          \`\`\`text
+          ${{ steps.diff.outputs.diff }}
+          \`\`\`
+          EOF
+          gh pr comment "${{ github.event.pull_request.number }}" --body-file comment.md

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775403759,
-        "narHash": "sha256-avkT2TR2Wh/TQTysYGFOkGiF5+2R2nS7TZOfQ4omieQ=",
-        "rev": "5e11f7acce6c3469bef9df154d78534fa7ae8b6c",
+        "lastModified": 1775888245,
+        "narHash": "sha256-qTVvODr6edFBLD2lncXPF8yTQeCafZUuKVtpV3Xb3yM=",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre975217.5e11f7acce6c/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre978638.13043924aaa7/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-qTVvODr6edFBLD2lncXPF8yTQeCafZUuKVtpV3Xb3yM=",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "lastModified": 1775403759,
+        "narHash": "sha256-avkT2TR2Wh/TQTysYGFOkGiF5+2R2nS7TZOfQ4omieQ=",
+        "rev": "5e11f7acce6c3469bef9df154d78534fa7ae8b6c",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre978638.13043924aaa7/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre975217.5e11f7acce6c/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
Debugging package failure such as https://github.com/kachick/wait-other-jobs/pull/1307 easier.

Based on https://github.com/kachick/dotfiles/commit/ff6f8758583761c06eb989d093830323c8877a0c
 by using `nix store diff-closure` instead of dix.