### PR TITLE
Add auto-commit for build and lint diffs in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,28 @@ jobs:
       - name: Test, build, lint
         run: |
           deno task all
+      - name: Generate token
+        id: generate-token
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }} # TODO: Switch to client-id
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Fix and commit if diff exists
+        if: steps.generate-token.outputs.token != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          if ! (git add --intent-to-add . && git diff --exit-code); then
+            gh pr checkout ${{ github.event.pull_request.number }}
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add .
+            git commit -m "Fix lint or build diff"
+            git push origin HEAD
+          fi
       - name: Make sure there is no diff after build
+        if: steps.generate-token.outputs.token == ''
         run: |
           deno task check_no_git_diff


### PR DESCRIPTION
When a pull request has diffs after build or linting, automatically
commit those changes using a GitHub App token. This avoids manual
updates for routine tasks like dist/ updates or formatting fixes.

---

Make it easy to maintain PRs such as https://github.com/kachick/wait-other-jobs/pull/1312 and https://github.com/kachick/wait-other-jobs/pull/1313
