### PR TITLE
Fix git push authentication in auto-commit step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,17 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
+      - name: Generate token
+        id: generate-token
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }} # TODO: Switch to client-id
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
+          token: ${{ steps.generate-token.outputs.token || github.token }}
+          persist-credentials: true
       - uses: NixOS/nix-installer-action@main # There are no tagged releases
       - name: Install direnv
         run: |
@@ -69,13 +77,6 @@ jobs:
       - name: Test, build, lint
         run: |
           deno task all
-      - name: Generate token
-        id: generate-token
-        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ vars.APP_ID }} # TODO: Switch to client-id
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Fix and commit if diff exists
         if: steps.generate-token.outputs.token != ''
         shell: bash


### PR DESCRIPTION
Move token generation to the start and use it in actions/checkout with
persist-credentials: true. This ensures that the generated token is
available for git push, following the pattern in
sync-nix-vendor-hash.yml.

Follow-up: https://github.com/kachick/wait-other-jobs/pull/1316 by referring https://github.com/kachick/selfup/blob/9988b1dec3d2d5ab30ad49917d0ff5d705d40a57/.github/workflows/sync-nix-vendor-hash.yml#L23
