### PR TITLE
Change wait-list test target to avoid deadlocks

### DIFF
--- a/.github/workflows/itself.yml
+++ b/.github/workflows/itself.yml
@@ -161,8 +161,8 @@ jobs:
                 "optional": ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
               },
               {
-                "workflowFile": "merge-bot-pr.yml",
-                "jobName": "dependabot",
+                "workflowFile": "update-nixpkgs-and-versions-in-ci.yml",
+                "jobName": "update-nixpkgs",
                 "optional": true
               },
               {


### PR DESCRIPTION
In itself.yml's wait-list test job, we previously targeted
merge-bot-pr.yml (job: dependabot) to verify optional: true.

However, since ci.yml now automatically pushes auto-fix
commits to PRs, subsequent workflow runs on Dependabot PRs
are triggered by github-actions[bot] rather than dependabot[bot].
This means itself.yml is no longer skipped (as the actor is
not dependabot[bot]), while merge-bot-pr.yml still triggers
because the PR owner is still dependabot[bot].

As a result, a circular dependency occurs:
default_logic -> wait-list -> dependabot -> itself.yml jobs.

To resolve this deadlock while preserving tests for optional: true,
we replace the target with update-nixpkgs-and-versions-in-ci.yml.
This target does not call wait-other-jobs and thus cannot
cause circular dependencies, while it still only triggers
under specific conditions to test the optional flag logic.

Assisted-by: Gemini:gemini-3.1

---

Follow-up: https://github.com/kachick/wait-other-jobs/pull/1316, https://github.com/kachick/wait-other-jobs/pull/1317

Found in: https://github.com/kachick/wait-other-jobs/pull/1345, https://github.com/kachick/wait-other-jobs/pull/1329
